### PR TITLE
Add console frame buffer rendering for snake game

### DIFF
--- a/Snake/ConsoleFrameBuffer.cs
+++ b/Snake/ConsoleFrameBuffer.cs
@@ -1,0 +1,145 @@
+using System;
+
+internal sealed class ConsoleFrameBuffer
+{
+    private readonly int _width;
+    private readonly int _height;
+    private readonly Cell[,] _cells;
+    private readonly Cell[,] _backBuffer;
+    private readonly ConsoleColor _defaultForeground;
+    private readonly ConsoleColor _defaultBackground;
+
+    private struct Cell
+    {
+        public char Char;
+        public ConsoleColor? Foreground;
+        public ConsoleColor? Background;
+    }
+
+    private ConsoleFrameBuffer(int width, int height)
+    {
+        _width = width;
+        _height = height;
+        _cells = new Cell[width, height];
+        _backBuffer = new Cell[width, height];
+        _defaultForeground = Console.ForegroundColor;
+        _defaultBackground = Console.BackgroundColor;
+        Clear(' ', null, null);
+    }
+
+    public static ConsoleFrameBuffer? TryCreate(int width, int height)
+    {
+        try
+        {
+            if (Console.IsOutputRedirected)
+            {
+                return null;
+            }
+
+            int originalLeft = Console.CursorLeft;
+            int originalTop = Console.CursorTop;
+
+            // Probes whether the terminal allows addressing the requested area
+            Console.SetCursorPosition(Math.Min(width - 1, Math.Max(0, Console.BufferWidth - 1)),
+                                       Math.Min(height - 1, Math.Max(0, Console.BufferHeight - 1)));
+            Console.SetCursorPosition(originalLeft, originalTop);
+
+            return new ConsoleFrameBuffer(width, height);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public void Clear(char fillChar = ' ', ConsoleColor? fg = null, ConsoleColor? bg = null)
+    {
+        for (int y = 0; y < _height; y++)
+        {
+            for (int x = 0; x < _width; x++)
+            {
+                _cells[x, y].Char = fillChar;
+                _cells[x, y].Foreground = fg;
+                _cells[x, y].Background = bg;
+                _backBuffer[x, y].Char = fillChar;
+                _backBuffer[x, y].Foreground = fg;
+                _backBuffer[x, y].Background = bg;
+            }
+        }
+    }
+
+    public void SetCell(int x, int y, char ch, ConsoleColor? fg = null, ConsoleColor? bg = null)
+    {
+        if ((uint)x >= (uint)_width || (uint)y >= (uint)_height)
+        {
+            return;
+        }
+
+        _cells[x, y].Char = ch;
+        _cells[x, y].Foreground = fg;
+        _cells[x, y].Background = bg;
+    }
+
+    public void FillHorizontal(int x, int y, int length, char ch, ConsoleColor? fg = null, ConsoleColor? bg = null)
+    {
+        int start = Math.Max(0, x);
+        int end = Math.Min(_width, x + length);
+        for (int i = start; i < end; i++)
+        {
+            SetCell(i, y, ch, fg, bg);
+        }
+    }
+
+    public void Flush()
+    {
+        var currentFg = Console.ForegroundColor;
+        var currentBg = Console.BackgroundColor;
+
+        for (int y = 0; y < _height; y++)
+        {
+            for (int x = 0; x < _width; x++)
+            {
+                ref Cell target = ref _cells[x, y];
+                ref Cell previous = ref _backBuffer[x, y];
+
+                if (target.Char == previous.Char && target.Foreground == previous.Foreground && target.Background == previous.Background)
+                {
+                    continue;
+                }
+
+                Console.SetCursorPosition(x, y);
+
+                ConsoleColor fg = target.Foreground ?? _defaultForeground;
+                ConsoleColor bg = target.Background ?? _defaultBackground;
+
+                if (currentFg != fg)
+                {
+                    Console.ForegroundColor = fg;
+                    currentFg = fg;
+                }
+
+                if (currentBg != bg)
+                {
+                    Console.BackgroundColor = bg;
+                    currentBg = bg;
+                }
+
+                Console.Write(target.Char);
+
+                previous.Char = target.Char;
+                previous.Foreground = target.Foreground;
+                previous.Background = target.Background;
+            }
+        }
+
+        if (currentFg != _defaultForeground)
+        {
+            Console.ForegroundColor = _defaultForeground;
+        }
+
+        if (currentBg != _defaultBackground)
+        {
+            Console.BackgroundColor = _defaultBackground;
+        }
+    }
+}

--- a/Snake/Program.cs
+++ b/Snake/Program.cs
@@ -16,19 +16,6 @@ using System.Runtime.InteropServices;
 class Program
 {
     // ===== Snake-Config =====
-    const int FieldWidth = 40;
-    const int FieldHeight = 20;
-
-    const char BorderCh = '█';
-    const char HeadCh = '■';
-    const char BodyCh = '■';
-    const char FoodCh = '●';
-
-    static readonly ConsoleColor BorderFg = ConsoleColor.DarkGray;
-    static readonly ConsoleColor HeadFg = ConsoleColor.Green;
-    static readonly ConsoleColor BodyFg = ConsoleColor.DarkGreen;
-    static readonly ConsoleColor FoodFg = ConsoleColor.Red;
-
     static readonly Random Rng = new Random();
 
     // ===== Musik / Settings =====
@@ -218,206 +205,19 @@ class Program
 
         while (true)
         {
-            int score = RunSnakeRound();
+            var game = new SnakeGame(Rng);
+            int score = game.PlayRound();
             if (score < 0) // ESC -> zurück
                 return;
 
             SaveScore(score);
 
-            Console.SetCursorPosition(0, FieldHeight + 2);
+            Console.SetCursorPosition(0, SnakeGame.RequiredHeight + 2);
             Console.ResetColor();
             Console.WriteLine($"Score gespeichert: {score}.  (Enter = neue Runde, ESC = zurück zum Menü)");
             var key = Console.ReadKey(true).Key;
             if (key == ConsoleKey.Escape) return;
         }
-    }
-
-    // ---------- Snake ----------
-    static int RunSnakeRound()
-    {
-        Console.CursorVisible = false;
-        Console.Clear();
-        EnsureWindowSize();
-        DrawBorder();
-
-        var snake = new LinkedList<(int x, int y)>();
-        int startX = FieldWidth / 2;
-        int startY = FieldHeight / 2;
-        snake.AddFirst((startX, startY));
-        snake.AddLast((startX - 1, startY));
-        snake.AddLast((startX - 2, startY));
-
-        var occupied = new HashSet<(int x, int y)>(snake);
-
-        int dx = 1, dy = 0;
-
-        var food = SpawnFood(occupied);
-        DrawAt(food.x, food.y, FoodCh, FoodFg);
-
-        int score = 0;
-        int tickMs = 120;
-        var timer = new Stopwatch();
-        timer.Start();
-
-        bool gameOver = false;
-
-        TitleBar(score);
-
-        while (!gameOver)
-        {
-            // Eingabe
-            if (Console.KeyAvailable)
-            {
-                var key = Console.ReadKey(true).Key;
-                switch (key)
-                {
-                    case ConsoleKey.LeftArrow:
-                    case ConsoleKey.A: if (dx != 1) { dx = -1; dy = 0; } break;
-                    case ConsoleKey.RightArrow:
-                    case ConsoleKey.D: if (dx != -1) { dx = 1; dy = 0; } break;
-                    case ConsoleKey.UpArrow:
-                    case ConsoleKey.W: if (dy != 1) { dx = 0; dy = -1; } break;
-                    case ConsoleKey.DownArrow:
-                    case ConsoleKey.S: if (dy != -1) { dx = 0; dy = 1; } break;
-                    case ConsoleKey.Escape:
-                        Console.CursorVisible = true;
-                        return -1; // zurück zum Menü
-                }
-            }
-
-            if (timer.ElapsedMilliseconds >= tickMs)
-            {
-                timer.Restart();
-
-                var head = snake.First!.Value;
-                int nx = head.x + dx;
-                int ny = head.y + dy;
-
-                // Wände
-                if (nx <= 0 || nx >= FieldWidth - 1 || ny <= 0 || ny >= FieldHeight - 1)
-                {
-                    gameOver = true; break;
-                }
-                // Körper
-                if (occupied.Contains((nx, ny)))
-                {
-                    gameOver = true; break;
-                }
-
-                // Zeichnen
-                DrawAt(nx, ny, HeadCh, HeadFg);
-                DrawAt(head.x, head.y, BodyCh, BodyFg);
-
-                snake.AddFirst((nx, ny));
-                occupied.Add((nx, ny));
-
-                bool ate = (nx, ny) == food;
-
-                if (ate)
-                {
-                    score++;
-                    TitleBar(score);
-                    TryBeep(880, 80); // kurzer Beep beim Essen
-
-                    if (tickMs > 45) tickMs -= 3; // schneller
-                    food = SpawnFood(occupied);
-                    DrawAt(food.x, food.y, FoodCh, FoodFg);
-                }
-                else
-                {
-                    // Schwanz entfernen
-                    var tail = snake.Last!.Value;
-                    snake.RemoveLast();
-                    occupied.Remove(tail);
-                    DrawAt(tail.x, tail.y, ' ', null);
-                }
-            }
-
-            Thread.Sleep(1);
-        }
-
-        // Game Over
-        Console.SetCursorPosition(0, FieldHeight);
-        Console.ResetColor();
-        Console.WriteLine($"\nGame Over! Score: {score}   (Enter = weiter, ESC = zurück zum Menü)");
-        Console.CursorVisible = true;
-
-        // Warten auf Taste
-        while (true)
-        {
-            var k = Console.ReadKey(true).Key;
-            if (k == ConsoleKey.Enter) break;
-            if (k == ConsoleKey.Escape) return -1;
-        }
-
-        return score;
-    }
-
-    static void TitleBar(int score)
-    {
-        Console.SetCursorPosition(0, FieldHeight);
-        Console.ResetColor();
-        Console.Write($" Score: {score}    (WASD/Pfeile, ESC Menü)   ");
-    }
-
-    static void DrawBorder()
-    {
-        for (int x = 0; x < FieldWidth; x++)
-        {
-            DrawAt(x, 0, BorderCh, BorderFg);
-            DrawAt(x, FieldHeight - 1, BorderCh, BorderFg);
-        }
-        for (int y = 0; y < FieldHeight; y++)
-        {
-            DrawAt(0, y, BorderCh, BorderFg);
-            DrawAt(FieldWidth - 1, y, BorderCh, BorderFg);
-        }
-    }
-
-    static (int x, int y) SpawnFood(HashSet<(int x, int y)> occupied)
-    {
-        int x, y;
-        do
-        {
-            x = Rng.Next(1, FieldWidth - 1);
-            y = Rng.Next(1, FieldHeight - 1);
-        } while (occupied.Contains((x, y)));
-        return (x, y);
-    }
-
-    static void DrawAt(int x, int y, char ch, ConsoleColor? fg)
-    {
-        Console.SetCursorPosition(x, y);
-        var prevFg = Console.ForegroundColor;
-        if (fg.HasValue) Console.ForegroundColor = fg.Value;
-        Console.Write(ch);
-        if (fg.HasValue) Console.ForegroundColor = prevFg;
-    }
-
-    static void EnsureWindowSize()
-    {
-        try
-        {
-            if (Console.WindowWidth < FieldWidth || Console.WindowHeight < FieldHeight + 2)
-            {
-                Console.SetWindowSize(
-                    Math.Max(Console.WindowWidth, FieldWidth),
-                    Math.Max(Console.WindowHeight, FieldHeight + 2));
-            }
-            if (Console.BufferWidth < FieldWidth || Console.BufferHeight < FieldHeight + 2)
-            {
-                Console.SetBufferSize(
-                    Math.Max(Console.BufferWidth, FieldWidth),
-                    Math.Max(Console.BufferHeight, FieldHeight + 2));
-            }
-        }
-        catch { /* manche Terminals erlauben das nicht */ }
-    }
-
-    static void TryBeep(int freq, int ms)
-    {
-        try { Console.Beep(freq, ms); }
-        catch { /* auf manchen Systemen nicht verfügbar */ }
     }
 
     // ===== Musik: Start/Wechsel/Stop =====

--- a/Snake/SnakeGame.cs
+++ b/Snake/SnakeGame.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+internal sealed class SnakeGame
+{
+    public const int PlayfieldWidth = 40;
+    public const int PlayfieldHeight = 20;
+    private const int HudHeight = 3;
+
+    public static int RequiredHeight => PlayfieldHeight + HudHeight;
+
+    private const char BorderCh = '█';
+    private const char HeadCh = '■';
+    private const char BodyCh = '■';
+    private const char FoodCh = '●';
+
+    private static readonly ConsoleColor BorderFg = ConsoleColor.DarkGray;
+    private static readonly ConsoleColor HeadFg = ConsoleColor.Green;
+    private static readonly ConsoleColor BodyFg = ConsoleColor.DarkGreen;
+    private static readonly ConsoleColor FoodFg = ConsoleColor.Red;
+    private static readonly ConsoleColor HudFg = ConsoleColor.Gray;
+
+    private readonly Random _rng;
+    private ConsoleFrameBuffer? _frameBuffer;
+    private bool _useBuffer;
+
+    private int TotalHeight => PlayfieldHeight + HudHeight;
+
+    public SnakeGame(Random rng)
+    {
+        _rng = rng;
+    }
+
+    public int PlayRound()
+    {
+        Console.CursorVisible = false;
+        Console.Clear();
+        EnsureWindowSize();
+
+        _frameBuffer = ConsoleFrameBuffer.TryCreate(PlayfieldWidth, TotalHeight);
+        _useBuffer = _frameBuffer != null;
+
+        _frameBuffer?.Clear(' ');
+
+        DrawBorder();
+
+        var snake = new LinkedList<(int x, int y)>();
+        int startX = PlayfieldWidth / 2;
+        int startY = PlayfieldHeight / 2;
+        snake.AddFirst((startX, startY));
+        snake.AddLast((startX - 1, startY));
+        snake.AddLast((startX - 2, startY));
+
+        var occupied = new HashSet<(int x, int y)>(snake);
+
+        int dx = 1, dy = 0;
+
+        var food = SpawnFood(occupied);
+
+        DrawAt(food.x, food.y, FoodCh, FoodFg);
+        foreach (var segment in snake)
+        {
+            DrawAt(segment.x, segment.y, segment == snake.First!.Value ? HeadCh : BodyCh, segment == snake.First!.Value ? HeadFg : BodyFg);
+        }
+
+        DrawTitleBar(score: 0);
+        DrawLegend();
+        DrawPauseOverlay(isPaused: false);
+
+        _frameBuffer?.Flush();
+
+        int score = 0;
+        int tickMs = 120;
+        var timer = new Stopwatch();
+        timer.Start();
+
+        bool gameOver = false;
+        bool paused = false;
+
+        while (!gameOver)
+        {
+            if (Console.KeyAvailable)
+            {
+                var key = Console.ReadKey(true).Key;
+                switch (key)
+                {
+                    case ConsoleKey.LeftArrow:
+                    case ConsoleKey.A:
+                        if (dx != 1) { dx = -1; dy = 0; }
+                        break;
+                    case ConsoleKey.RightArrow:
+                    case ConsoleKey.D:
+                        if (dx != -1) { dx = 1; dy = 0; }
+                        break;
+                    case ConsoleKey.UpArrow:
+                    case ConsoleKey.W:
+                        if (dy != 1) { dx = 0; dy = -1; }
+                        break;
+                    case ConsoleKey.DownArrow:
+                    case ConsoleKey.S:
+                        if (dy != -1) { dx = 0; dy = 1; }
+                        break;
+                    case ConsoleKey.P:
+                    case ConsoleKey.Spacebar:
+                        paused = !paused;
+                        DrawPauseOverlay(paused);
+                        FlushIfNeeded();
+                        break;
+                    case ConsoleKey.Escape:
+                        RestoreHudBeforeExit();
+                        return -1;
+                }
+            }
+
+            if (paused)
+            {
+                Thread.Sleep(16);
+                continue;
+            }
+
+            if (timer.ElapsedMilliseconds >= tickMs)
+            {
+                timer.Restart();
+
+                var head = snake.First!.Value;
+                int nx = head.x + dx;
+                int ny = head.y + dy;
+
+                if (nx <= 0 || nx >= PlayfieldWidth - 1 || ny <= 0 || ny >= PlayfieldHeight - 1)
+                {
+                    gameOver = true;
+                }
+                else if (occupied.Contains((nx, ny)))
+                {
+                    gameOver = true;
+                }
+                else
+                {
+                    snake.AddFirst((nx, ny));
+                    occupied.Add((nx, ny));
+
+                    bool ate = (nx, ny) == food;
+
+                    DrawAt(nx, ny, HeadCh, HeadFg);
+                    DrawAt(head.x, head.y, BodyCh, BodyFg);
+
+                    if (ate)
+                    {
+                        score++;
+                        DrawTitleBar(score);
+                        TryBeep(880, 80);
+
+                        if (tickMs > 45)
+                        {
+                            tickMs -= 3;
+                        }
+
+                        food = SpawnFood(occupied);
+                        DrawAt(food.x, food.y, FoodCh, FoodFg);
+                    }
+                    else
+                    {
+                        var tail = snake.Last!.Value;
+                        snake.RemoveLast();
+                        occupied.Remove(tail);
+                        DrawAt(tail.x, tail.y, ' ', null);
+                    }
+
+                    FlushIfNeeded();
+                }
+            }
+
+            Thread.Sleep(1);
+        }
+
+        FlushIfNeeded();
+
+        Console.SetCursorPosition(0, TotalHeight);
+        Console.ResetColor();
+        Console.WriteLine($"\nGame Over! Score: {score}   (Enter = weiter, ESC = zurück zum Menü)");
+        Console.CursorVisible = true;
+
+        while (true)
+        {
+            var k = Console.ReadKey(true).Key;
+            if (k == ConsoleKey.Enter) break;
+            if (k == ConsoleKey.Escape) return -1;
+        }
+
+        return score;
+    }
+
+    private void FlushIfNeeded()
+    {
+        _frameBuffer?.Flush();
+    }
+
+    private void DrawTitleBar(int score)
+    {
+        string text = $" Score: {score}    (WASD/Pfeile, ESC Menü, P Pause)";
+        WriteHudLine(PlayfieldHeight, text, HudFg);
+    }
+
+    private void DrawLegend()
+    {
+        string legend = $" {HeadCh} Kopf  {BodyCh} Körper  {FoodCh} Futter";
+        WriteHudLine(PlayfieldHeight + 1, legend, HudFg);
+    }
+
+    private void DrawPauseOverlay(bool isPaused)
+    {
+        string message = isPaused ? " == P A U S E ==  (P oder Leertaste) " : string.Empty;
+        WriteHudLine(PlayfieldHeight + 2, message, HudFg);
+    }
+
+    private void WriteHudLine(int y, string text, ConsoleColor color)
+    {
+        string padded = text.Length > PlayfieldWidth ? text[..PlayfieldWidth] : text.PadRight(PlayfieldWidth);
+        for (int i = 0; i < padded.Length && i < PlayfieldWidth; i++)
+        {
+            DrawAt(i, y, padded[i], color);
+        }
+    }
+
+    private void DrawBorder()
+    {
+        for (int x = 0; x < PlayfieldWidth; x++)
+        {
+            DrawAt(x, 0, BorderCh, BorderFg);
+            DrawAt(x, PlayfieldHeight - 1, BorderCh, BorderFg);
+        }
+
+        for (int y = 0; y < PlayfieldHeight; y++)
+        {
+            DrawAt(0, y, BorderCh, BorderFg);
+            DrawAt(PlayfieldWidth - 1, y, BorderCh, BorderFg);
+        }
+    }
+
+    private (int x, int y) SpawnFood(HashSet<(int x, int y)> occupied)
+    {
+        int x, y;
+        do
+        {
+            x = _rng.Next(1, PlayfieldWidth - 1);
+            y = _rng.Next(1, PlayfieldHeight - 1);
+        }
+        while (occupied.Contains((x, y)));
+
+        return (x, y);
+    }
+
+    private void DrawAt(int x, int y, char ch, ConsoleColor? fg)
+    {
+        if (_useBuffer)
+        {
+            _frameBuffer!.SetCell(x, y, ch, fg);
+            return;
+        }
+
+        Console.SetCursorPosition(x, y);
+        var prevFg = Console.ForegroundColor;
+        if (fg.HasValue)
+        {
+            Console.ForegroundColor = fg.Value;
+        }
+        Console.Write(ch);
+        if (fg.HasValue)
+        {
+            Console.ForegroundColor = prevFg;
+        }
+    }
+
+    private void EnsureWindowSize()
+    {
+        try
+        {
+            if (Console.WindowWidth < PlayfieldWidth || Console.WindowHeight < TotalHeight + 2)
+            {
+                Console.SetWindowSize(
+                    Math.Max(Console.WindowWidth, PlayfieldWidth),
+                    Math.Max(Console.WindowHeight, TotalHeight + 2));
+            }
+            if (Console.BufferWidth < PlayfieldWidth || Console.BufferHeight < TotalHeight + 2)
+            {
+                Console.SetBufferSize(
+                    Math.Max(Console.BufferWidth, PlayfieldWidth),
+                    Math.Max(Console.BufferHeight, TotalHeight + 2));
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private void RestoreHudBeforeExit()
+    {
+        FlushIfNeeded();
+        Console.CursorVisible = true;
+    }
+
+    private static void TryBeep(int freq, int ms)
+    {
+        try
+        {
+            Console.Beep(freq, ms);
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `ConsoleFrameBuffer` that stores characters and colors before flushing the scene
- refactor the snake round into `SnakeGame` so drawing goes through the buffer with HUD updates and pause overlay
- keep a direct drawing fallback when the terminal does not support buffered rendering and hook the game into the menu loop

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c3ef80c0832ca5183e1a5c1d841e